### PR TITLE
Remove "compiler.base" settings mechanism

### DIFF
--- a/design/031-remove_compiler_base.md
+++ b/design/031-remove_compiler_base.md
@@ -1,0 +1,41 @@
+# Proposal: Remove "compiler.base" settings mechanism
+
+
+| **Status**        |                                                   |
+|:------------------|:--------------------------------------------------|
+| **RFC #**         | [031](https://github.com/conan-io/tribe/pull/31)  |
+| **Submitted**     | 2022-01-17                                        |
+| **Tribe votes**   |                                                   |
+
+
+## Summary
+
+The mechanism of defining that a compiler such as “intel” in the settings.yml definition will kind of extend other existing compilers (such as “intel” having as a base either “gcc” in Linux or “msvc” in Windows) will be removed. Instead, a full definition of the compiler will be necessary, as the new IntelOneApi (via ``intel-cc`` setting has already been proposed in Conan 1.X).
+
+
+## Motivation
+
+When this feature was introduced, following feedback of users mainly using the Intel compiler, it seemed useful. Such users were reporting binary compatibility between packages built with Intel and packages built with the underlying gcc or Visual compiler, so, apparently, having a built-in definition of such base compatibility made sense.
+
+But, since then, many of these users have now reported that such a feature is not adding value at all, and in fact in some cases it might be more confusing and problematic than the problem it tries to solve. Users are now directly defining specific settings per-package to explicitly define which configuration they want, and following their feedback, the new ``intel-cc`` compiler setting for IntelOneApi was defined, without such mechanism.
+
+Removing the feature will simplify the implementation of generators and toolchains, and users wanting to implement some kind of fallback compatibility between different compilers will be able to use other mechanisms.
+
+
+## Detailed Design
+
+Note that this proposal doesn’t remove any ``compatible_packages`` mechanism. Actually, we are considering how to better represent such compatibility, with other better UX than coding it directly in the recipes ``package_id()`` method. This proposal only removes the ``settings.yml`` definition of the ``intel`` and ``mcst-lcc`` compilers, and replace them with a fully self-contained one, adding all the details they need to represent their binaries, without resorting to the definition of another compiler.
+
+
+## Implementation details
+
+The ``settings.yml`` file will be updated with the removal of the “base” subsettings, and the generators and code will remove all the checks of ``self.settings.compiler.base``.
+
+
+## Migration plan
+
+The Intel compiler already got a new ``intel-cc`` new compiler in 1.X that is fully independent. While it only supports at the moment IntelOneApi, it can be extended for previous versions if necessary.
+
+The same process needs to be done for the ``mcst-lcc`` compiler in 1.X, defining a new independent one.
+
+The resulting ``package_ids`` are different, so for the new settings there shouldn’t be any conflict with binaries.

--- a/design/031-remove_compiler_base.md
+++ b/design/031-remove_compiler_base.md
@@ -10,7 +10,11 @@
 
 ## Summary
 
-The mechanism of defining that a compiler such as “intel” in the settings.yml definition will kind of extend other existing compilers (such as “intel” having as a base either “gcc” in Linux or “msvc” in Windows) will be removed. Instead, a full definition of the compiler will be necessary, as the new IntelOneApi (via ``intel-cc`` setting has already been proposed in Conan 1.X).
+The ``compiler.base`` subsettings mechanism will be removed. Some compilers such has ``intel`` define in *settings.yml* a subsetting called ``base``, that can point to another existing compiler like ``gcc`` or ``msvc`` to which
+it assumes binary compatibility. It doesn't replicate the whole ``gcc`` or ``msvc`` subsettings, but instead uses
+a yaml syntax (e.g: ``<<: *visual_studio``). It also assumed full binary compatibility between the "intel" compiler and the "base" compiler (being it Visual in Windows and gcc in Linux).
+
+This mechanism will be completely removed. The ``base`` definition will be removed from *settings.yml*. Instead, a full definition of the compiler will be necessary, as the new IntelOneApi (via ``intel-cc`` setting has already been proposed in Conan 1.X). Also, automatic implicit binary compatibility between compilers will be removed.
 
 
 ## Motivation

--- a/design/031-remove_compiler_base.md
+++ b/design/031-remove_compiler_base.md
@@ -10,11 +10,11 @@
 
 ## Summary
 
-The ``compiler.base`` subsettings mechanism will be removed. Some compilers such has ``intel`` define in *settings.yml* a subsetting called ``base``, that can point to another existing compiler like ``gcc`` or ``msvc`` to which
-it assumes binary compatibility. It doesn't replicate the whole ``gcc`` or ``msvc`` subsettings, but instead uses
-a yaml syntax (e.g: ``<<: *visual_studio``). It also assumed full binary compatibility between the "intel" compiler and the "base" compiler (being it Visual in Windows and gcc in Linux).
+The ``compiler.base`` subsetting mechanism will be removed. Some compilers such as ``intel`` define in *settings.yml* a subsetting called ``base``, that can point to another existing compiler like ``gcc`` or ``Visual Studio`` to which
+it assumes binary compatibility. It doesn't replicate the whole ``gcc`` or ``Visual Studio`` subsettings, but instead uses
+a yaml syntax (e.g: ``<<: *visual_studio``) to effectively copy the "base" compiler settings. It also assumed full binary compatibility between the "intel" compiler and the "base" compiler (being it Visual in Windows and gcc in Linux).
 
-This mechanism will be completely removed. The ``base`` definition will be removed from *settings.yml*. Instead, a full definition of the compiler will be necessary, as the new IntelOneApi (via ``intel-cc`` setting has already been proposed in Conan 1.X). Also, automatic implicit binary compatibility between compilers will be removed.
+This mechanism will be completely removed. The ``base`` definition will be removed from *settings.yml*. Instead, a full definition of the compiler will be necessary, as the new IntelOneApi (via ``intel-cc``) setting has already done in Conan 1.X. Also, automatic implicit binary compatibility between compilers will be removed.
 
 
 ## Motivation


### PR DESCRIPTION
The mechanism of defining that a compiler such as “intel” in the settings.yml definition will kind of extend other existing compilers (such as “intel” having as a base either “gcc” in Linux or “msvc” in Windows) will be removed. Instead, a full definition of the compiler will be necessary, as the new IntelOneApi (via ``intel-cc`` setting has already been proposed in Conan 1.X).

The potential expected benefits of the "compiler.base" mechanism are not worth it compared with the complexity they bring. Some users, the ones that promoted this feature have already requested its removal. It also seems to have no extended usage beyond the previous ``intel`` and ``mcst-lcc`` compilers.

---

 * Upvote 👍  or downvote 👎  to show acceptance or not to the proposal (other reactions will be ignored)
   + Please, use 👀  to acknowledge you've read it, but it doesn't affect your workflow
 * Comment and reviews to suggest changes to all (or part) of the proposal.