### PR TITLE
[Update proposal] Propose Python minimum version support updates

### DIFF
--- a/design/003-codebase-python.md
+++ b/design/003-codebase-python.md
@@ -9,7 +9,8 @@
 ---
 
 ## Summary
-Declare **Python 3.6** as the minimum Python version supported.
+Declare **Python 3.6** as the minimum Python version supported for Conan 2.0 launch.
+Declare a Python version support policy for 12 months after the minimum supported version has officially become End Of Life (EOL).
 
 
 ## Motivation
@@ -24,6 +25,11 @@ that will help to improve the codebase and write more maintainable source:
  * Formatted string literals a.k.a. _f-strings_.
  * Type hints for classes and instance variables.
 
+ There is also a support problem when Python officially declares versions EOL, because 
+ dependencies stop supporting those versions and can break the Conan application. Conan
+ can pin and restrict the usage of those dependencies, but that also has security implications,
+ so it is not something that should be extended too much over time.
+
 
 ## Proposal
 Python 3.6 will be the minimal supported version. Conan 2.0 is expected to be released
@@ -32,6 +38,10 @@ on 2021, by that date Python 3.6 will be the oldest release alive (EOL on Decemb
 
 About Linux distros: starting on Debian 10 Buster (July 2019), the [Python 3
 version installed is Python 3.7](https://wiki.debian.org/Python). Ubuntu 18.04 (April 2018) already included Python 3.6.
+
+Conan will drop support for Python versions 12 months **after** their official EOL date, that is,
+it will continue testing and supporting one year and a half beyond that date. When one version support
+becomes deprecated, the next Python version will be used as the minimum tested and supported one. 
 
 
 ## Alternative Approaches

--- a/design/003-codebase-python.md
+++ b/design/003-codebase-python.md
@@ -27,7 +27,7 @@ that will help to improve the codebase and write more maintainable source:
 
  There is also a support problem when Python officially declares versions EOL, because 
  dependencies stop supporting those versions and can break the Conan application. Conan
- can pin and restrict the usage of those dependencies, but that also has security implications,
+ can pin and restrict the usage of those dependencies newer versions, but that also has security implications,
  so it is not something that should be extended too much over time.
 
 
@@ -40,7 +40,7 @@ About Linux distros: starting on Debian 10 Buster (July 2019), the [Python 3
 version installed is Python 3.7](https://wiki.debian.org/Python). Ubuntu 18.04 (April 2018) already included Python 3.6.
 
 Conan will drop support for Python versions 12 months **after** their official EOL date, that is,
-it will continue testing and supporting one year and a half beyond that date. When one version support
+it will continue testing and supporting one year beyond that date. When one version support
 becomes deprecated, the next Python version will be used as the minimum tested and supported one. 
 
 


### PR DESCRIPTION
Hi Tribe!

The Tribe proposal in PR https://github.com/conan-io/tribe/pull/3 about "using a fixed Python minimum supported version" is becoming outdated at the fast pace that the Python foundation is implementing for their releases (see https://endoflife.date/python). The minimum Python 3.6 that was agreed back then has already been declared End Of Life (EOL). Keeping Conan running with unsupported Python versions suppose and increasing challenge as time passes, involving breaking dependencies (Conan dependencies no longer supported EOL versions), and security risks if those dependencies cannot be updated.

Therefore, we propose a moving minimum supported Python version, that will extend 12 months over the official Python EOL. That means that Conan 2.0 launch will still support Python 3.6, but some time after it launch, in December 2022, it might start to require Python 3.7. 

We know that this could be a challenging requirement for some orgs that can't upgrade Python versions easily, so as always we will try our best to extend as much as possible the backwards compatibility. But at some point it can really become a burden for evolution and a security liability.


---

 * Upvote 👍  or downvote 👎  to show acceptance or not to the proposal (other reactions will be ignored)
   + Please, use 👀  to acknowledge you've read it, but it doesn't affect your workflow
 * Comment and reviews to suggest changes to all (or part) of the proposal.